### PR TITLE
SSR Comptability with UglifyJs

### DIFF
--- a/lib/addStylesServer.js
+++ b/lib/addStylesServer.js
@@ -9,7 +9,7 @@ module.exports = function (parentId, list, isProduction) {
       styles = context._styles = {}
       Object.defineProperty(context, 'styles', {
         enumberable: true,
-        get () {
+        get : function() {
           return (
             context._renderedStyles ||
             (context._renderedStyles = renderStyles(styles))
@@ -71,11 +71,10 @@ function renderStyles (styles) {
   var css = ''
   for (var key in styles) {
     var style = styles[key]
-    css += `<style data-vue-ssr-id="${
-      style.ids.join(' ')
-    }"${
-      style.media ? ` media="${style.media}"` : ''
-    }>${style.css}</style>`
+    css += '<style data-vue-ssr-id="' + style.ids.join(' ') +
+        (style.media ? ( 'media=' + style.media ) : '') +
+        style.css +
+        '</style>'
   }
   return css
 }

--- a/lib/addStylesServer.js
+++ b/lib/addStylesServer.js
@@ -71,10 +71,9 @@ function renderStyles (styles) {
   var css = ''
   for (var key in styles) {
     var style = styles[key]
-    css += '<style data-vue-ssr-id="' + style.ids.join(' ') +
-        (style.media ? ( 'media=' + style.media ) : '') +
-        style.css +
-        '</style>'
+    css += '<style data-vue-ssr-id="' + style.ids.join(' ') + '"' +
+        (style.media ? ( 'media="' + style.media + '"' ) : '') + '>' +
+        style.css + '</style>'
   }
   return css
 }


### PR DESCRIPTION
When building SSR bundles using webpack, UglifyJs throws errors like this:
```
 ERROR in bootstrap-vue.common.js from UglifyJs
SyntaxError: Unexpected token punc «)», expected punc «(» [./~/vue-style-loader/lib/addStylesServer.js:12,0][bootstrap-vue.common.js:7450,13]
```
This is because uglifyJS doesn't supports Template literals & Function shorthands. This PR simply uses older syntax in order to resolve this problem :)
