### PR TITLE
add data-vue-ssr-id for client hydration

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,11 +35,12 @@ module.exports.pitch = function (remainingRequest) {
     'if(content.locals) module.exports = content.locals;'
   ]
 
+  var options = loaderUtils.getOptions(this)
   if (!isServer) {
     // on the client: dynamic inject + hot-reload
     var code = [
       '// add the styles to the DOM',
-      'var update = require(' + addStylesClientPath + ')(' + id + ', content, ' + isProduction + ');'
+      'var update = require(' + addStylesClientPath + ')(' + id + ', content, ' + isProduction + ', ' + JSON.stringify(options) + ');'
     ]
     if (!isProduction) {
       code = code.concat([

--- a/lib/addStylesClient.js
+++ b/lib/addStylesClient.js
@@ -42,13 +42,17 @@ var singletonElement = null
 var singletonCounter = 0
 var isProduction = false
 var noop = function () {}
+var options = null
+var ssridKey = 'data-vue-ssr-id'
 
 // Force single-tag solution on IE6-9, which has a hard limit on the # of <style>
 // tags it will allow on a page
 var isOldIE = typeof navigator !== 'undefined' && /msie [6-9]\b/.test(navigator.userAgent.toLowerCase())
 
-module.exports = function (parentId, list, _isProduction) {
+module.exports = function (parentId, list, _isProduction, _options) {
   isProduction = _isProduction
+
+  options = _options || {}
 
   var styles = listToStyles(parentId, list)
   addStylesToDom(styles)
@@ -113,7 +117,7 @@ function createStyleElement () {
 
 function addStyle (obj /* StyleObjectPart */) {
   var update, remove
-  var styleElement = document.querySelector('style[data-vue-ssr-id~="' + obj.id + '"]')
+  var styleElement = document.querySelector('style['+ssridKey+'~="' + obj.id + '"]')
 
   if (styleElement) {
     if (isProduction) {
@@ -194,6 +198,9 @@ function applyToTag (styleElement, obj) {
 
   if (media) {
     styleElement.setAttribute('media', media)
+  }
+  if (options.ssrid) {
+    styleElement.setAttribute(ssridKey, obj.id)
   }
 
   if (sourceMap) {

--- a/lib/addStylesClient.js
+++ b/lib/addStylesClient.js
@@ -43,7 +43,7 @@ var singletonCounter = 0
 var isProduction = false
 var noop = function () {}
 var options = null
-var ssridKey = 'data-vue-ssr-id'
+var ssrIdKey = 'data-vue-ssr-id'
 
 // Force single-tag solution on IE6-9, which has a hard limit on the # of <style>
 // tags it will allow on a page
@@ -117,7 +117,7 @@ function createStyleElement () {
 
 function addStyle (obj /* StyleObjectPart */) {
   var update, remove
-  var styleElement = document.querySelector('style['+ssridKey+'~="' + obj.id + '"]')
+  var styleElement = document.querySelector('style[' + ssrIdKey + '~="' + obj.id + '"]')
 
   if (styleElement) {
     if (isProduction) {
@@ -199,7 +199,7 @@ function applyToTag (styleElement, obj) {
   if (media) {
     styleElement.setAttribute('media', media)
   }
-  if (options.ssrid) {
+  if (options.ssrId) {
     styleElement.setAttribute(ssridKey, obj.id)
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
feature

**Did you add tests for your changes?**
no unit test, but has used in our project.

**If relevant, did you update the README?**
no

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
在处理ssr问题时，我们采用了类似prerender-spa-plugin的方案，通过phantom生成服务端页面。
在这个过程中，由于还是基于client的流程在执行，无法给style标签增加data-vue-ssr-id属性，导致在页面访问时，存在style代码重复插入的问题。

如果这个修改可行的化，建议将data-vue-ssr-id健名改成id，以更通用。

<!-- Try to link to an open issue for more information. -->
https://github.com/vuejs/vue-style-loader/issues/10

**Does this PR introduce a breaking change?**
no

**Other information**
