### PR TITLE
judge `isVue` from loader options also

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports.pitch = function (remainingRequest) {
   var id = JSON.stringify(hash(request + this.resourcePath))
   var options = loaderUtils.getOptions(this) || {}
 
-  // direct css import from js --> direct for non vue file and manually call `styles.__inject__(ssrContext)` in component lifecycle
+  // direct css import from js --> direct, or manually call `styles.__inject__(ssrContext)` with `manualInject` option
   // css import from vue file --> component lifecycle linked
   // style embedded in vue file --> component lifecycle linked
   var isVue = /"vue":true/.test(remainingRequest) || options.manualInject

--- a/index.js
+++ b/index.js
@@ -18,13 +18,13 @@ module.exports.pitch = function (remainingRequest) {
   var addStylesServerPath = loaderUtils.stringifyRequest(this, '!' + path.join(__dirname, 'lib/addStylesServer.js'))
 
   var request = loaderUtils.stringifyRequest(this, '!!' + remainingRequest)
-  var id = JSON.stringify(hash(request) + path.relative(__dirname, this.resourcePath))
+  var id = JSON.stringify(hash(request + this.resourcePath))
   var options = loaderUtils.getOptions(this) || {}
 
   // direct css import from js --> direct for non vue file and manually call `styles.__inject__(ssrContext)` in component lifecycle
   // css import from vue file --> component lifecycle linked
   // style embedded in vue file --> component lifecycle linked
-  var isVue = /"vue":true/.test(remainingRequest) || options.vue
+  var isVue = /"vue":true/.test(remainingRequest) || options.manualInject
 
   var shared = [
     '// style-loader: Adds some css to the DOM by adding a <style> tag',

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports.pitch = function (remainingRequest) {
   var addStylesServerPath = loaderUtils.stringifyRequest(this, '!' + path.join(__dirname, 'lib/addStylesServer.js'))
 
   var request = loaderUtils.stringifyRequest(this, '!!' + remainingRequest)
-  var id = JSON.stringify(hash(request))
+  var id = JSON.stringify(hash(request) + path.relative(__dirname, this.resourcePath))
 
   // direct css import from js --> direct for non vue file and manually call `styles.__inject__(ssrContext)` in component lifecycle
   // css import from vue file --> component lifecycle linked

--- a/index.js
+++ b/index.js
@@ -19,11 +19,12 @@ module.exports.pitch = function (remainingRequest) {
 
   var request = loaderUtils.stringifyRequest(this, '!!' + remainingRequest)
   var id = JSON.stringify(hash(request) + path.relative(__dirname, this.resourcePath))
+  var options = loaderUtils.getOptions(this) || {}
 
   // direct css import from js --> direct for non vue file and manually call `styles.__inject__(ssrContext)` in component lifecycle
   // css import from vue file --> component lifecycle linked
   // style embedded in vue file --> component lifecycle linked
-  var isVue = /"vue":true/.test(remainingRequest) || loaderUtils.getOptions(this).vue
+  var isVue = /"vue":true/.test(remainingRequest) || options.vue
 
   var shared = [
     '// style-loader: Adds some css to the DOM by adding a <style> tag',

--- a/index.js
+++ b/index.js
@@ -20,10 +20,10 @@ module.exports.pitch = function (remainingRequest) {
   var request = loaderUtils.stringifyRequest(this, '!!' + remainingRequest)
   var id = JSON.stringify(hash(request))
 
-  // direct css import from js --> direct (how does this work when inside an async chunk? ...just don't do it)
+  // direct css import from js --> direct for non vue file and manually call `styles.__inject__(ssrContext)` in component lifecycle
   // css import from vue file --> component lifecycle linked
   // style embedded in vue file --> component lifecycle linked
-  var isVue = /"vue":true/.test(remainingRequest)
+  var isVue = /"vue":true/.test(remainingRequest) || loaderUtils.getOptions(this).vue
 
   var shared = [
     '// style-loader: Adds some css to the DOM by adding a <style> tag',


### PR DESCRIPTION
`remainingRequest` is string, and can only be used with `css-loader?${JSON.stringify(options)}`, if we are not using .vue file (jsx in .js file for example), with `vue-style-loader?vue` we will be able to manually handle styles for ssr also.

``` js
// manually
import styles from 'styles.scss'

export default {
  beforeCreate() { // or create a mixin for this purpose
    if(styles.__inject__) {
      styles.__inject__(this.$ssrContext)
    }
  }

  render() {
    return <div class={styles.heading}>Hello World</div>
  }
}



// global mixin example
Vue.mixin({
  beforeCreate() {
    const { styles } = this.$options
    if(styles && styles.__inject__) {
      styles.__inject__(this.$ssrContext)
    }
  }
})


import styles from 'styles.scss'

export default {
  styles,
  render() {
    return <div class={styles.heading}>Hello World</div>
  }
}
```

Id should be generated via request and resourcePath relative to `__dirname`, because request is relative to required resource, so if there are same filenames under different folder, it will be same, so I add resourcePath.


And more, vue ssr pattern will be able to use with other js framework!

Example: https://github.com/JounQin/react-hackernews with https://github.com/JounQin/react-style-loader
  