### PR TITLE
Detect and skip WebWorker scripts

### DIFF
--- a/lib/addStylesClient.js
+++ b/lib/addStylesClient.js
@@ -5,9 +5,10 @@
 */
 
 var hasDocument = typeof document !== 'undefined'
+var isWebWorker = typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope
 
 if (typeof DEBUG !== 'undefined' && DEBUG) {
-  if (!hasDocument) {
+  if (!isWebWorker && !hasDocument) {
     throw new Error(
     'vue-style-loader cannot be used in a non-browser environment. ' +
     "Use { target: 'node' } in your Webpack config to indicate a server-rendering environment."
@@ -48,6 +49,10 @@ var noop = function () {}
 var isOldIE = typeof navigator !== 'undefined' && /msie [6-9]\b/.test(navigator.userAgent.toLowerCase())
 
 module.exports = function (parentId, list, _isProduction) {
+  if (isWebWorker) {
+    return
+  }
+  
   isProduction = _isProduction
 
   var styles = listToStyles(parentId, list)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
This PR fixes #16 

**Did you add tests for your changes?**
No

**If relevant, did you update the README?**
No

**Summary**
When importing styles from a WebWorker script, vue-style-loader fails because there is no document in the scope. This PR implements [WebWorker detection](https://stackoverflow.com/questions/7931182/reliably-detect-if-the-script-is-executing-in-a-web-worker) and skip style imports in these scripts.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No

**Other information**
