### PR TITLE
remove duplicate declaration of `options`

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,6 @@ module.exports.pitch = function (remainingRequest) {
     'if(content.locals) module.exports = content.locals;'
   ]
 
-  var options = loaderUtils.getOptions(this)
   if (!isServer) {
     // on the client: dynamic inject + hot-reload
     var code = [


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
refactoring

**Did you add tests for your changes?**

No

**If relevant, did you update the README?**

No need

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
https://github.com/vuejs/vue-style-loader/blob/master/index.js#L22

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No

**Other information**

@yyx990803 I notice you changed `path.relative(__dirname, this.resourcePath)` to `this.resourcePath` directly in https://github.com/JounQin/react-style-loader/commit/643aa4da1aec1913285ca2b05353900d4c37350d, that's not correct because `this.resourcePath` is an absolute path and will change in different devices, which will cause unexpected changes.