### PR TITLE
get relative path for `this. resourcePath`

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports.pitch = function (remainingRequest) {
   var addStylesServerPath = loaderUtils.stringifyRequest(this, '!' + path.join(__dirname, 'lib/addStylesServer.js'))
 
   var request = loaderUtils.stringifyRequest(this, '!!' + remainingRequest)
-  var id = JSON.stringify(hash(request + this.resourcePath))
+  var id = JSON.stringify(hash(request + path.relative(__dirname, this.resourcePath)))
   var options = loaderUtils.getOptions(this) || {}
 
   // direct css import from js --> direct, or manually call `styles.__inject__(ssrContext)` with `manualInject` option


### PR DESCRIPTION
`this.resourcePath` is an absolute path and will change in different devices, which will cause unexpected changes.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

refactoring

**Did you add tests for your changes?**

No

**If relevant, did you update the README?**

No

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

`this.resourcePath` is an absolute path and will change in different devices, which will cause unexpected changes.

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No

**Other information**
