### PR TITLE
Fix inconsistent hashes between Windows and POSIX systems

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,8 @@ module.exports.pitch = function (remainingRequest) {
   var addStylesShadowPath = loaderUtils.stringifyRequest(this, '!' + path.join(__dirname, 'lib/addStylesShadow.js'))
 
   var request = loaderUtils.stringifyRequest(this, '!!' + remainingRequest)
-  var id = JSON.stringify(hash(request + path.relative(__dirname, this.resourcePath)))
+  var relPath = path.relative(__dirname, this.resourcePath).replace(/\\/g, '/')
+  var id = JSON.stringify(hash(request + relPath))
   var options = loaderUtils.getOptions(this) || {}
 
   // direct css import from js --> direct, or manually call `styles.__inject__(ssrContext)` with `manualInject` option


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Bugfix

**Did you add tests for your changes?**
I did not add tests for my changes, but I did verify the fix works by making my webpack bundle on a Linux system, getting one ID or hash, then running the same files and configuration on a Windows system and getting a different hash.

**If relevant, did you update the README?**
No.

**Summary**
When using this loader on a project where we have Windows, Linux (and maybe OS X) users,
I discovered we were getting different bundles if one user bundled using a POSIX system, and another bundled **the same files** on a Windows system.
I believe I only encountered this issue when bundling in development mode.
_Edit:_ You could say it's related to #19. It fixed the issue for different devices using the same system type. This PR fixes the same issue for different devices using different system types.

**Does this PR introduce a breaking change?**
I do not believe it is a breaking change.

**Other information**
I don't have an issue to link, however, I used [this PR](https://github.com/pymedusa/Medusa/pull/4878/commits/46fedf2158316c270ff2a45d99caf8b9d08dbe4b) to test my fix.
It includes a fix for `vue-loader` as well, which I will open a PR for, soon.

This is a simple issue, but if you think a reproduction setup is needed to see the issue in action, let me know and I'll it set up.