### PR TITLE
Add injectInImportOrder option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ This is a fork based on [style-loader](https://github.com/webpack/style-loader).
 
   Type: `boolean`. Add `data-vue-ssr-id` attribute to injected `<style>` tags even when not in Node.js. This can be used with pre-rendering (instead of SSR) to avoid duplicate style injection on hydration.
 
+- **injectInImportOrder** (draft):
+
+  Type: `boolean`. Inject HTML DOM Style in import order like in production with ExtractTextPlugin. When value is `true`, `ssrId` option is forced to `true` too.
+  
+  Developed by Ilhasoft's Web Team.
+
 ## Differences from `style-loader`
 
 ### Server-Side Rendering Support

--- a/lib/addStylesClient.js
+++ b/lib/addStylesClient.js
@@ -40,19 +40,23 @@ var stylesInDom = {/*
 var head = hasDocument && (document.head || document.getElementsByTagName('head')[0])
 var singletonElement = null
 var singletonCounter = 0
+var parentId = null
 var isProduction = false
 var noop = function () {}
 var options = null
+var beforeOrder = null
 var ssrIdKey = 'data-vue-ssr-id'
 
 // Force single-tag solution on IE6-9, which has a hard limit on the # of <style>
 // tags it will allow on a page
 var isOldIE = typeof navigator !== 'undefined' && /msie [6-9]\b/.test(navigator.userAgent.toLowerCase())
 
-module.exports = function (parentId, list, _isProduction, _options) {
+module.exports = function (_parentId, list, _isProduction, _options, _beforeOrder) {
+  parentId = _parentId
   isProduction = _isProduction
 
   options = _options || {}
+  beforeOrder = _beforeOrder
 
   var styles = listToStyles(parentId, list)
   addStylesToDom(styles)
@@ -111,7 +115,37 @@ function addStylesToDom (styles /* Array<StyleObject> */) {
 function createStyleElement () {
   var styleElement = document.createElement('style')
   styleElement.type = 'text/css'
-  head.appendChild(styleElement)
+  
+  if (options.injectInImportOrder) {
+    var allStyleElems = document.querySelectorAll('style[' + ssrIdKey + ']');
+    var beforeStyleElem = null;
+    
+    for (var i = beforeOrder.length - 1; i >= 0; i--) {
+      var before = beforeOrder[i];
+      
+      for (var j = allStyleElems.length - 1; j >= 0; j--) {
+        var styleElem = allStyleElems[j];
+        var styleElemId = styleElem.getAttribute(ssrIdKey).split(':')[0];
+        
+        if (before === styleElemId) {
+          beforeStyleElem = styleElem;
+          break;
+        }
+      }
+      
+      if (beforeStyleElem) {
+        break;
+      }
+    }
+
+    if (beforeStyleElem) {
+      head.insertBefore(styleElement, beforeStyleElem.nextElementSibling);
+    } else {
+      head.appendChild(styleElement)
+    }
+  } else {
+    head.appendChild(styleElement)
+  }
   return styleElement
 }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Add injectInImportOrder option. Inject HTML DOM Style in import order like in production with ExtractTextPlugin.

**Did you add tests for your changes?**
No

**If relevant, did you update the README?**
Yes

**Summary**
In development mode style tags are injected by demand without respect import order, this generate unreliable environment, a developer environment distinct of production environment.

**Does this PR introduce a breaking change?**
No
