### PR TITLE
feat: add Insertinto option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,28 @@ This is a fork based on [style-loader](https://github.com/webpack/style-loader).
 
   Type: `boolean`. Add `data-vue-ssr-id` attribute to injected `<style>` tags even when not in Node.js. This can be used with pre-rendering (instead of SSR) to avoid duplicate style injection on hydration.
 
+- **insertInto** (4.2.0+):
+
+  Type: `string|function`. Inserts `<style>` to the given position. Returns an `Element` or a `ShadowRoot` where `<style>` tags will be inserted to. If passing `function` to it,  it will be converted to string directly append inline the code, so object literal shorthand syntax is not allowed here.
+
+  ```js
+  {
+    loader: 'vue-style-loader',
+    options: {
+      // all style tag will insert to #my-root-element
+      insertInto: function () {
+        return document.querySelector('#my-root-element')
+      },
+      // or insert into shadow root
+      insertInto: function () {
+        return document.querySelector('#my-root-element').shadowRoot
+      },
+      // or using function string
+      insertInto: 'function() { return document.querySelector("#my-root-element") }',
+    }
+  }
+  ```
+
 ## Differences from `style-loader`
 
 ### Server-Side Rendering Support

--- a/index.js
+++ b/index.js
@@ -22,6 +22,14 @@ module.exports.pitch = function (remainingRequest) {
   var id = JSON.stringify(hash(request + relPath))
   var options = loaderUtils.getOptions(this) || {}
 
+  var insertInto
+  if (typeof options.insertInto === 'function') {
+    insertInto = options.insertInto.toString()
+  }
+  if (typeof options.insertInto === 'string') {
+    insertInto = options.insertInto
+  }
+
   // direct css import from js --> direct, or manually call `styles.__inject__(ssrContext)` with `manualInject` option
   // css import from vue file --> component lifecycle linked
   // style embedded in vue file --> component lifecycle linked
@@ -55,8 +63,10 @@ module.exports.pitch = function (remainingRequest) {
     // on the client: dynamic inject + hot-reload
     var code = [
       '// add the styles to the DOM',
+      'var options = ' + JSON.stringify(options),
+      insertInto ? 'options.insertInto = ' + insertInto : '',
       'var add = require(' + addStylesClientPath + ').default',
-      'var update = add(' + id + ', content, ' + isProduction + ', ' + JSON.stringify(options) + ');'
+      'var update = add(' + id + ', content, ' + isProduction + ', options);'
     ]
     if (!isProduction) {
       code = code.concat([

--- a/lib/addStylesClient.js
+++ b/lib/addStylesClient.js
@@ -109,15 +109,17 @@ function addStylesToDom (styles /* Array<StyleObject> */) {
 }
 
 function createStyleElement () {
+  var root = options.insertInto ? options.insertInto() : head
   var styleElement = document.createElement('style')
   styleElement.type = 'text/css'
-  head.appendChild(styleElement)
+  root.appendChild(styleElement)
   return styleElement
 }
 
 function addStyle (obj /* StyleObjectPart */) {
   var update, remove
-  var styleElement = document.querySelector('style[' + ssrIdKey + '~="' + obj.id + '"]')
+  var root = options.insertInto ? options.insertInto() : document
+  var styleElement = root.querySelector('style[' + ssrIdKey + '~="' + obj.id + '"]')
 
   if (styleElement) {
     if (isProduction) {


### PR DESCRIPTION
**What kind of change does this PR introduce?**
feature

**Did you add tests for your changes?**
No

**If relevant, did you update the README?**
Yes

**Summary**
Add `insertInto` option like in style-loader, allow to specify the parent element where style tags insert to,
makes it easy to insert style into shadow-root or other position, with hot reload feature avaliable while in development.

**Does this PR introduce a breaking change?**
No

**Other information**
