### PR TITLE
fix: also support passed ES Modules from `css-loader` in addition to CommonJS format

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,8 @@ module.exports.pitch = function (remainingRequest) {
     '',
     '// load the styles',
     'var content = require(' + request + ');',
+    // get default export if list is an ES Module (CSS Loader v4+)
+    "if(content.__esModule) content = content.default;",
     // content list format is [id, css, media, sourceMap]
     "if(typeof content === 'string') content = [[module.id, content, '']];",
     'if(content.locals) module.exports = content.locals;'


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Fix for new default behavior of [`css-loader`](https://github.com/webpack-contrib/css-loader) v4

**Did you add tests for your changes?**
No, due to small change and backwards compatibility. Happy to add if required.

**Summary**
Due to [`css-loader`](https://github.com/webpack-contrib/css-loader) using [ES Modules](https://github.com/webpack-contrib/css-loader#esmodule) as [the new default in v4](https://github.com/webpack-contrib/css-loader/releases/tag/v4.0.0), this module breaks when upgrading `css-loader` to latest (see #46, #42). This patch addresses that problem.

**Does this PR introduce a breaking change?**
No, tested to be backwards compatible.

**Other information**
Not sure what the future plans are for this module and whether it's still relevant when Vue 3 releases (I didn't see `vue-style-loader` listed as a dependency on vue3 bundles), so feel free to discard this patch if this module is to be phased out.

Fixes #46, Fixes #42  