### PR TITLE
fix: add esm interop

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ module.exports.pitch = function (remainingRequest) {
     '',
     '// load the styles',
     'var content = require(' + request + ');',
+    "if ('default' in content) { content = content.default; }",
     // content list format is [id, css, media, sourceMap]
     "if(typeof content === 'string') content = [[module.id, content, '']];",
     'if(content.locals) module.exports = content.locals;'


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
Fixes https://github.com/vuejs/vue-style-loader/issues/46
Repro: https://github.com/privatenumber/vue-css-loader-bug/

**Did you add tests for your changes?**
No. This adds a change to `pitch`, which isn't tested in this repo.
I tested locally though in my dev env.

**If relevant, did you update the README?**
Not relevant. Happens behind the scenes.

**Summary**
[css-loader](https://github.com/webpack-contrib/css-loader) started to enable `esModule` by default in [v4.0.0](esModule), which breaks the way `vue-style-loader` handles the CSS file exported by `css-loader`.

Specifically, the `list` [here](https://github.com/vuejs/vue-style-loader/blob/master/lib/listToStyles.js#L5) is now an ES module instead of an array, where there `default` property must be read.

Adding an ESM interop fixes this.


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
Nope.

**Other information**
