### PR TITLE
Enable SSR for webworker target

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ var qs = require('querystring')
 module.exports = function () {}
 
 module.exports.pitch = function (remainingRequest) {
-  var isServer = this.target === 'node'
+  var isServer = this.target === 'node' || this.target === 'webworker'
   var isProduction = this.minimize || process.env.NODE_ENV === 'production'
   var addStylesClientPath = loaderUtils.stringifyRequest(this, '!' + path.join(__dirname, 'lib/addStylesClient.js'))
   var addStylesServerPath = loaderUtils.stringifyRequest(this, '!' + path.join(__dirname, 'lib/addStylesServer.js'))


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

This enables SSR when the target is either `node` or `webworker`. The webworker environment does not have a global `document` and as a result fails to build. This is applicable for SSR in [cloudflare workers](https://workers.cloudflare.com/).

**Did you add tests for your changes?**

**If relevant, did you update the README?**

**Summary**
Enable SSR in `webworker` targets for use in cloudflare workers.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No

**Other information**
